### PR TITLE
[FEAT] Add Windows Building Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build tinyrigel
-        run: cargo build --release --all-features
+        run: cargo build --release --all-features --all-targets
 
       - name: Upload Windows Library
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: tinyrigel - Continuous Integration
+
+on:
+  push
+
+jobs:
+  build-win:
+    name: Build Windows Library
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+        
+      - name: Initialize Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo Packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build tinyrigel
+        run: cargo build --release --all-features
+
+      - name: Upload Windows Library
+        uses: actions/upload-artifact@v2
+        with:
+          name: tinyrigel-windows
+          path: |
+            target/release/tinyrigel.*
+            target/release/libtinyrigel.*
+            target/release/examples/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-        with:
-          lfs: true
         
       - name: Initialize Rust Toolchain
         uses: actions-rs/toolchain@v1

--- a/backends/windows-bindings/build.rs
+++ b/backends/windows-bindings/build.rs
@@ -1,8 +1,8 @@
 fn main() {
   windows::build!(
-    windows::devices::enumeration::*
-    windows::media::capture::*
-    windows::media::media_properties::*
+    windows::devices::enumeration::*,
+    windows::media::capture::*,
+    windows::media::media_properties::*,
     windows::storage::streams::*
   );
 }


### PR DESCRIPTION
This PR adds a small Github Action that automatically builds `tinyrigel` and uploads the build artifacts upon each push.

It also adds commas in `backends/windows-bindings/build.rs` because my Rust was complaining about it...

You can see the Github Actions (prior to merge) Here: https://github.com/zalo/tinyrigel/actions